### PR TITLE
Direct to GitHub issues

### DIFF
--- a/index.html
+++ b/index.html
@@ -65,6 +65,7 @@
 			<button type="button" class="btn btn-outline" href="#" onclick="copyToClipboard(event)">Copy</button>
 			<button type="button" class="btn btn-outline" href="#" onclick="downloadFile(event)">Download</button>
 			<button type="button" class="btn btn-outline" href="#" onclick="createProjectPR(event)">Create Pull Request</button>
+			<button type="button" class="btn btn-outline" href="#" onclick="createGitHubIssueForm(event)">Create GitHub Issue</button>
 			<button type="button" class="btn btn-outline" href="#" onclick="emailFile(event)">Email</button>
 		</div>
 

--- a/index.html
+++ b/index.html
@@ -64,7 +64,7 @@
         	<textarea class="form-control" rows="10" id="json-result" readonly></textarea>
 			<button type="button" class="btn btn-outline" href="#" onclick="copyToClipboard(event)">Copy</button>
 			<button type="button" class="btn btn-outline" href="#" onclick="downloadFile(event)">Download</button>
-			<button type="button" class="btn btn-outline" href="#" onclick="createProjectPR(event)">Create Pull Request</button>
+			<!-- <button type="button" class="btn btn-outline" href="#" onclick="createProjectPR(event)">Create Pull Request</button> -->
 			<button type="button" class="btn btn-outline" href="#" onclick="createGitHubIssueForm(event)">Create GitHub Issue</button>
 			<button type="button" class="btn btn-outline" href="#" onclick="createAutoGitHubIssue(event)">Auto-Create Issue (API Key Requied)</button>
 			<button type="button" class="btn btn-outline" href="#" onclick="emailFile(event)">Email</button>

--- a/index.html
+++ b/index.html
@@ -66,6 +66,7 @@
 			<button type="button" class="btn btn-outline" href="#" onclick="downloadFile(event)">Download</button>
 			<button type="button" class="btn btn-outline" href="#" onclick="createProjectPR(event)">Create Pull Request</button>
 			<button type="button" class="btn btn-outline" href="#" onclick="createGitHubIssueForm(event)">Create GitHub Issue</button>
+			<button type="button" class="btn btn-outline" href="#" onclick="createAutoGitHubIssue(event)">Auto-Create Issue (API Key Requied)</button>
 			<button type="button" class="btn btn-outline" href="#" onclick="emailFile(event)">Email</button>
 		</div>
 

--- a/js/formDataToJson.js
+++ b/js/formDataToJson.js
@@ -322,6 +322,72 @@ async function downloadFile(event) {
 	link.click();
 }
 
+// Creates Issue Title
+function generateIssueTitle(codeJSONObj) {
+	const resourceName = codeJSONObj['Resource Information']['Basic Information'][0]['Resource Name'] || "Unknown Name";
+	return `HHS Repository and Asset Tracking for: ${resourceName}`
+}
+
+// Creates Issue Body
+function generateIssueBody(codeJSONObj) {
+	const resourceNames = codeJSONObj['Resource Information']['Basic Information']
+		.map(resource => resource['Resource Name']).join(' \n ')
+
+	let body = "## HHS Repository and Asset Tracking Details\n\n";
+
+	body += `### This issue was created using HHS Repository and Asset Tracking form.\n`
+	body += `**The following resources are being tracked:**\n ${resourceNames}\n\n`
+	body += JSON.stringify(codeJSONObj, null, 2);
+
+	return body;
+}
+
+// Triggers new issue in GitHub
+async function createGitHubIssueForm(event) {
+	event.preventDefault();
+	
+	const textArea = document.getElementById("json-result");
+	const codeJSONObj = JSON.parse(textArea.value);
+
+	if (!textArea.value) {
+		alert("No data found! Please submit data first.");
+		return;
+	}
+
+	try {
+		codeJSONObj;
+	} catch (error) {
+		alert("Invalid JSON data. Please check form submission");
+	}
+
+	try {
+		const issueTitle = generateIssueTitle(codeJSONObj);
+		const issueBody = generateIssueBody(codeJSONObj);
+
+		const githubIssueURL = createGitHubNewIssueURL(issueTitle, issueBody);
+
+		window.open(githubIssueURL, '_blank');
+
+		alert("GitHub issue form opened in new tab. Please review and click 'Submit new issue' to create it.");
+
+	} catch (error) {
+		console.error("Error opening GitHub issue form:", error);
+		alert("Error opening GitHub issue form:" + error.message)
+	}
+}
+
+//Create GitHub URL
+function createGitHubNewIssueURL(title, body) {
+	const baseURL = "https://github.com/DSACMS/gh-datacall-form/issues/new";
+	const params = new URLSearchParams({
+		title: title,
+		body: body,
+		labels: 'Repository and asset tracking'
+	});
+
+	return `${baseURL}?${params.toString()}`;
+}
+
 // Triggers email(mailtolink)
 async function emailFile(event) {
 	event.preventDefault();
@@ -355,4 +421,5 @@ window.createCodeJson = createCodeJson;
 window.copyToClipboard = copyToClipboard;
 window.downloadFile = downloadFile;
 window.createProjectPR = createProjectPR;
+window.createGitHubIssueForm = createGitHubIssueForm;
 window.emailFile = emailFile;

--- a/js/formDataToJson.js
+++ b/js/formDataToJson.js
@@ -301,7 +301,6 @@ async function createProjectPR(event){
 		console.error("No API key found!");
 		alert("No API Key in submitted data! Please provide an API key");
 	}
-	//console.log(codeJSONObj)
 }
 
 // Triggers local file download
@@ -404,9 +403,6 @@ async function createAutoGitHubIssue(event) {
 	const apiKey = window.gh_api_key;
 
 	try {
-		// const { owner, repo } = getOrgAndRepoArgsGitHub("https://github.com/DSACMS/gh-datacall-form/issues/new");
-		// const baseURL = "https://github.com/DSACMS/gh-datacall-form/issues/new";
-		
 		const issueTitle = generateIssueTitle(codeJSONObj);
 		const issueBody = generateIssueBody(codeJSONObj);
 

--- a/js/formDataToJson.js
+++ b/js/formDataToJson.js
@@ -73,7 +73,7 @@ async function populateCodeJson(data) {
 	return codeJson;
 }
 
-// Creates code.json object
+// Creates json object
 async function createCodeJson(data) {
 	delete data.submit;
 	const codeJson = await populateCodeJson(data);
@@ -86,7 +86,7 @@ async function createCodeJson(data) {
 	document.getElementById("json-result").value = jsonString;
 }
 
-// Copies code.json to clipboard
+// Copies json to clipboard
 async function copyToClipboard(event){
 	event.preventDefault();
 
@@ -175,7 +175,7 @@ async function createBranchOnProject(projectURL, token)
 async function addFileToBranch(projectURL, token, JSONObj)
 {
 	const {owner, repo} = getOrgAndRepoArgsGitHub(projectURL);
-	const FILE_PATH = 'code.json'
+	const FILE_PATH = 'code-anti-data-call.json'
 	const createFileApiUrl = `https://api.github.com/repos/${owner}/${repo}/contents/${FILE_PATH}`;
 	const encodedContent = btoa(JSONObj);
 	console.log("Content: ", encodedContent);
@@ -229,8 +229,8 @@ async function createPR(projectURL, token)
 				'X-GitHub-Api-Version': "2022-11-28"
 			},
 			body: JSON.stringify({
-				title: "Add code.json to Project",
-				body: "Add generated code.json file to project. Code.json was generated via codejson-generator form site.",
+				title: "Add code-anti-data-call.json to Project",
+				body: "Add generated code-anti-data-call.json file to project. code-anti-data-call.json was generated via codejson-generator form site.",
 				head: NEW_BRANCH,
 				base: 'main',
 
@@ -315,7 +315,7 @@ async function downloadFile(event) {
 	// Create anchor element and create download link
 	const link = document.createElement("a");
 	link.href = URL.createObjectURL(blob);
-	link.download = "code.json";
+	link.download = "code-anti-data-call.json";
 
 	// Trigger the download
 	link.click();
@@ -332,7 +332,7 @@ function generateIssueTitle(JSONObj) {
 
 // Creates Issue Body
 function generateIssueBody(JSONObj) {
-	const resourceNames = JSONObj['Resource Information']['Basic Information']
+	const resourceNames = JSONObj['HHS Source Code - Resource Information']['Basic Information']
 		.map(resource => resource['Resource Name']).join(' \n ')
 
 	let body = "## HHS Repository and Asset Tracking Details\n\n";
@@ -380,11 +380,16 @@ async function createGitHubIssueForm(event) {
 
 // Create GitHub URL
 function createGitHubNewIssueURL(title, body) {
+	const textArea = document.getElementById("json-result");
+	const JSONObj = JSON.parse(textArea.value);
+	const agency = JSONObj["HHS Division"];
+	const match = agency.match(/\(([^)]+)\)/);
+
 	const baseURL = "https://github.com/DSACMS/gh-datacall-form/issues/new";
 	const params = new URLSearchParams({
 		title: title,
 		body: body,
-		labels: ['repository', 'assets', 'agency']
+		labels: ['repository', 'assets', match[1]]
 	});
 
 	return `${baseURL}?${params.toString()}`;
@@ -422,6 +427,11 @@ async function createAutoGitHubIssue(event) {
 }
 
 async function createIssueOnGitHub(token, title, body) {
+	const textArea = document.getElementById("json-result");
+	const JSONObj = JSON.parse(textArea.value);
+	const agency = JSONObj["HHS Division"];
+	const match = agency.match(/\(([^)]+)\)/);
+
 	const createIssueAPIURL = "https://api.github.com/repos/DSACMS/gh-datacall-form/issues";
 
 	const response = await fetch(createIssueAPIURL, 
@@ -435,7 +445,7 @@ async function createIssueOnGitHub(token, title, body) {
 			body: JSON.stringify({
 				title: title,
 				body: body,
-				labels: ['repository', 'assets', 'agency']
+				labels: ['repository', 'assets', match[1]]
 			})
 		});
 
@@ -444,6 +454,7 @@ async function createIssueOnGitHub(token, title, body) {
 		if (response.ok) {
 			console.log('Issue created successfully:', data);
 			console.log('Issue URL:', data.html_url);
+			alert('Issue created!', data.html_url);
 			return;
 		} else {
 			console.error('Error creating issue:', data);
@@ -466,8 +477,8 @@ async function emailFile(event) {
 
         const jsonString = JSON.stringify(cleanData, null, 2);
 
-        const subject = "Code.json generator Results";
-        const body = `Hello,\n\nHere are the code.json results:\n\n${jsonString}\n\nThank you!`;
+        const subject = "HHS Source Code Anti-Data Call Results";
+        const body = `Hello,\n\nHere is your response:\n\n${jsonString}\n\nThank you!`;
 
         const recipients = ["opensource@cms.hhs.gov"];
 

--- a/schemas/schema.json
+++ b/schemas/schema.json
@@ -1,33 +1,17 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema#",
-    "title": "HHS Repository and Asset Tracking",
-    "description": "Track repositories, codespaces, and resources funded by HHS offices",
+    "title": "HHS Source Code “Anti-Data Call” — Repository and Asset Tracking",
+    "description": "Track source code repositories, codespaces, and resources funded by HHS offices. This short questionnaire will take <5 minutes per HHS repository.",
     "type": "object",
     "properties": {
         "items": {
-            "First Name": {
-                "type": "string",
-                "description": "First Name"
-            },
-            "Last Name": {
-                "type": "string",
-                "description": "Last Name"
-            },
-            "HHS Email": {
-                "type": "string",
-                "format": "email",
-                "description": "What is your HHS or HHS Division email address?"
-            },
-            "Job Title": {
-                "type": "string",
-                "description": "What is your current job title?"
-            },
             "HHS Division": {
                 "type": "string",
                 "description": "What is your divison within HHS?",
                 "enum": [
                     "Administration for Children and Families (ACF)",
                     "Administration for Community Living (ACL)",
+                    "Administration for a Healthy America (AHA)",
                     "Agency for Healthcare Research and Quality (AHRQ)",
                     "Agency for Toxic Substances and Disease Registry (ATSDR)",
                     "Centers for Disease Control and Prevention (CDC)",
@@ -62,9 +46,9 @@
                 "type": "string",
                 "description": "What Office or Program do you belong to?"
             },
-            "Resource Information": {
+            "HHS Source Code - Resource Information": {
                 "type": "object",
-                "description": "An object containing description of the usage/restrictions regarding the release",
+                "description": "If the Source Code POC differs from the HHS POC completing this questionnaire, please provide your contact information below. ",
                 "properties": {
                     "Basic Information": {
                         "type": "array",
@@ -107,19 +91,15 @@
                                         "Contractor managed"
                                     ]
                                 },
-                                "POC First Name": {
+                                "Source Code POC Name": {
                                     "type": "string",
-                                    "description": "Resource project manager or POC First Name"
+                                    "description": "Resource project manager or POC First and Last Name"
                                 },
-                                "POC Last Name": {
-                                    "type": "string",
-                                    "description": "Resource project manager or POC Last Name"
-                                },
-                                "POC Phone Number": {
+                                "Source Code POC Phone Number": {
                                     "type": "string",
                                     "description": "Resource project manager or POC Phone Number"
                                 },
-                                "POC Email": {
+                                "Source Code POC Email": {
                                     "type": "string",
                                     "format": "email",
                                     "description": "Resource project manager or POC Email"
@@ -129,47 +109,40 @@
                                 "Resource Name",
                                 "Resource Link",
                                 "Date Created",
-                                "Status"
+                                "Status",
+                                "Management Type",
+                                "Source Code POC Name",
+                                "Source Code POC Email"
                             ]
                         }
                     }
                 },
                 "additionalProperties": false,
                 "required": [
-                    "Resource Information"
+                    "HHS Source Code - Resource Information"
                 ]
             },
-            "POC First Name": {
+            "HHS POC": {
                 "type": "string",
-                "description": "Resource project manager or POC First Name"
+                "description": "First and Last Name of HHS POC"
             },
-            "POC Last Name": {
+            "HHS POC Job Title": {
                 "type": "string",
-                "description": "Resource project manager or POC Last Name"
+                "description": "What is your current job title?"
             },
-            "POC Phone Number": {
+            "HHS POC Phone Number": {
                 "type": "string",
-                "description": "Resource project manager or POC Phone Number"
+                "description": "What is your phone number?"
             },
-            "POC Email": {
+            "HHS POC Email": {
                 "type": "string",
                 "format": "email",
-                "description": "Resource project manager or POC Email"
+                "description": "What is your HHS or HHS Division email address?"
             }
         }
     },
     "required": [
-        "First Name",
-        "Last Name",
-        "HHS Email",
-        "Title",
         "HHS Division",
-        "Resource Name",
-        "Resource Link",
-        "Date Created",
-        "Status",
-        "POC First Name",
-        "POC Last Name",
-        "POC Email"
+        "HHS Source Code - Resource Information"
     ]
 }


### PR DESCRIPTION
## Problem
Users are unable to push an issue directly to a private GitHub repository

## Solution
Two functions added `createAutoGitHubIssue` and `createIssueOnGitHub` to allow a user to create an issue pre-populated with a json object directly in GitHub using an API key.

## Result:
Users may fill out the form, adding an API key and have an issue automatically populate in GitHub.

## Note:
User must have write permissions in order to send an issue to GitHub

## Test
Test in browser
Send issue

<img width="765" alt="Screenshot 2025-06-06 at 7 41 16 AM" src="https://github.com/user-attachments/assets/b7da8e3c-5db1-4486-8695-9a9f9039b5e0" />
